### PR TITLE
Include module directory name to sourcemap

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,13 @@ module.exports = function(input, inputMap) {
 			});
 			return;
 		}
+		var pwd = process.cwd();
+		if (context.substring(0, pwd.length) === pwd) {
+			context = context.substr(pwd.length + 1);
+		}
+		map.sources = map.sources.map(function(source) {
+			return path.join(context, source);
+		});
 		callback(null, input.replace(match[0], ''), map);
 	}
 }


### PR DESCRIPTION
source-map-loader doesn't include directory name of modules with source maps in node_modules. Before publishing i prebuild babel sources with sourcemaps: https://github.com/zerkalica/babelfish-plus

I produce source maps with babel src --source-maps --out-dir . and publish node module with sourcemaps.

I use this module in project https://github.com/zerkalica/immutable-di-todomvc
webpack.config.js

``` js
preloaders: {
    [
                test: /\.js$/,
                exclude: /(?:src)/,
                include: /(?:node_modules|bower_components)/,
                loader: 'source-map-loader'
    ]
}
```

source-map-loader does not include module directory name in node_modules, and stores file names into root of source tree.
