### PR TITLE
Charset in inline-source-map support

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var baseRegex = "\\s*[@#]\\s*sourceMappingURL\\s*=\\s*([^\\s]*)",
 	// Matches // .... comments
 	regex2 = new RegExp("//"+baseRegex+"($|\n|\r\n?)"),
 	// Matches DataUrls
-	regexDataUrl = /data:[^;\n]+;base64,(.*)/;
+	regexDataUrl = /data:[^;\n]+(?:;charset=[^;\n]+)?;base64,(.*)/;
 
 module.exports = function(input, inputMap) {
 	this.cacheable && this.cacheable();

--- a/test/fixtures/charset-inline-source-map.js
+++ b/test/fixtures/charset-inline-source-map.js
@@ -1,0 +1,3 @@
+with SourceMap
+//    @    sourceMappingURL    =    data:application/source-map;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiY2hhcnNldC1pbmxpbmUtc291cmNlLW1hcC5qcyIsInNvdXJjZXMiOlsiY2hhcnNldC1pbmxpbmUtc291cmNlLW1hcC50eHQiXSwic291cmNlc0NvbnRlbnQiOlsid2l0aCBTb3VyY2VNYXAiXSwibWFwcGluZ3MiOiJBQUFBIn0=
+// comment

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,4 +141,23 @@ describe("source-map-loader", function() {
 			done();
 		});
 	});
+
+	it("should process inlined SourceMaps with charset", function(done) {
+		execLoader(path.join(__dirname, "fixtures", "charset-inline-source-map.js"), function(err, res, map, deps, warns) {
+			should.equal(err, null);
+			warns.should.be.eql([]);
+			should.equal(res, "with SourceMap\n\n// comment"),
+			map.should.be.eql({
+				"version":3,
+				"file":"charset-inline-source-map.js",
+				"sources":[
+					"charset-inline-source-map.txt"
+				],
+				"sourcesContent":["with SourceMap"],
+				"mappings":"AAAA"
+			});
+			deps.should.be.eql([]);
+			done();
+		});
+	});
 });


### PR DESCRIPTION
Hello, it seems that if a charset is specified in an inline source maps the loader does not detect the base64 and triggers a warning.

This PR add the support for the charset by changing a bit the regular exprssion regexDataUrl.