### PR TITLE
feat: ensure module paths in source map include full path from current working directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(input, inputMap) {
 	var resolve = this.resolve;
 	var addDependency = this.addDependency;
 	var emitWarning = this.emitWarning || function() {};
-	var params = loaderUtils.parseQuery(this.query);
+	var params = loaderUtils.getOptions(this) || {};
 	var match = input.match(regex1) || input.match(regex2);
 	if(match) {
 		var url = match[1];

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = function(input, inputMap) {
 	var resolve = this.resolve;
 	var addDependency = this.addDependency;
 	var emitWarning = this.emitWarning || function() {};
+	var params = loaderUtils.parseQuery(this.query);
 	var match = input.match(regex1) || input.match(regex2);
 	if(match) {
 		var url = match[1];
@@ -91,6 +92,21 @@ module.exports = function(input, inputMap) {
 			});
 			return;
 		}
+
+		if (params.includeModulePaths) {
+			// Ensure module paths include full path from current working directory
+			var pwd = process.cwd();
+			if (context.substring(0, pwd.length) === pwd) {
+				context = context.substr(pwd.length + 1);
+			}
+			map.sources = map.sources.map(function(source) {
+				if (source.substring(0, pwd.length) === pwd) {
+					return source.substr(pwd.length + 1);
+				}
+				return path.join(context, source);
+			});
+		}
+
 		callback(null, input.replace(match[0], ''), map);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     }
   ],
   "dependencies": {
-    "loader-utils": "~0.2.2",
-    "source-map": "~0.1.33",
-    "async": "^0.9.0"
+    "async": "^0.9.0",
+    "loader-utils": "~1.0.3",
+    "source-map": "~0.1.33"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,41 +3,58 @@ var fs = require("fs");
 var should = require("should");
 var loader = require("../");
 
-function execLoader(filename, callback, includeModulePaths) {
+function loaderRunner(filename, callback) {
 	var async = false;
 	var deps = [];
 	var warns = [];
-	var context = {
-		context: path.dirname(filename),
-		resolve: function(context, request, callback) {
-			process.nextTick(function() {
-				var p = path.join(context, request);
-				if(fs.existsSync(p))
-					callback(null, p);
-				else
-					callback(new Error("File not found"));
-			});
+
+	var runner = {
+		context: {
+			context: path.dirname(filename),
+			resolve: function(context, request, callback) {
+				process.nextTick(function() {
+					var p = path.join(context, request);
+					if(fs.existsSync(p))
+						callback(null, p);
+					else
+						callback(new Error("File not found"));
+				});
+			},
+			addDependency: function(dep) {
+				deps.push(dep);
+			},
+			emitWarning: function(warn) {
+				warns.push(warn);
+			},
+			callback: function(err, res, map) {
+				async = true;
+				callback(err, res, map, deps, warns);
+			},
+			async: function() {
+				async = true;
+				return this.callback;
+			}
 		},
-		addDependency: function(dep) {
-			deps.push(dep);
-		},
-		emitWarning: function(warn) {
-			warns.push(warn);
-		},
-		callback: function(err, res, map) {
-			async = true;
-			callback(err, res, map, deps, warns);
-		},
-		async: function() {
-			async = true;
-			return this.callback;
-		},
-		query: includeModulePaths ? '?includeModulePaths' : null
+		execute: function () {
+			// Remove CRs to make test line ending invariant
+			var fixtureContent = fs.readFileSync(filename, "utf-8").replace(/\r/g, '');
+			var res = loader.call(runner.context, fixtureContent);
+			if(!async) return callback(null, res, null, deps, warns);
+		}
 	};
-	// Remove CRs to make test line ending invariant
-	var fixtureContent = fs.readFileSync(filename, "utf-8").replace(/\r/g, '');
-	var res = loader.call(context, fixtureContent);
-	if(!async) return callback(null, res, null, deps, warns);
+
+	return runner;
+}
+
+function execLoader(filename, callback) {
+	var runner = loaderRunner(filename, callback);
+	return runner.execute();
+}
+
+function execModulePathLoader(filename, callback) {
+	var runner = loaderRunner(filename, callback);
+	runner.context.query = "?includeModulePaths";
+	return runner.execute();
 }
 
 describe("source-map-loader", function() {
@@ -183,23 +200,23 @@ describe("source-map-loader", function() {
 	});
 
 	it("should prepend the full path from the current working directory to the module", function(done) {
-		execLoader(path.join(__dirname, "fixtures", "external-source-map.js"), function(err, res, map, deps, warns) {
+		execModulePathLoader(path.join(__dirname, "fixtures", "external-source-map.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
 			map.sources.should.be.eql([
 				"test/fixtures/external-source-map.txt"
 			]);
 			done();
-		}, true);
+		});
 	});
 	it("should prepend the full path from the current working directory to the module (external sources)", function(done) {
-		execLoader(path.join(__dirname, "fixtures", "external-source-map2.js"), function(err, res, map, deps, warns) {
+		execModulePathLoader(path.join(__dirname, "fixtures", "external-source-map2.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
 			map.sources.should.be.eql([
 				"test/fixtures/external-source-map2.txt"
 			]);
 			done();
-		}, true);
+		});
 	});
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,7 @@ var fs = require("fs");
 var should = require("should");
 var loader = require("../");
 
-function execLoader(filename, callback) {
+function execLoader(filename, callback, includeModulePaths) {
 	var async = false;
 	var deps = [];
 	var warns = [];
@@ -31,7 +31,8 @@ function execLoader(filename, callback) {
 		async: function() {
 			async = true;
 			return this.callback;
-		}
+		},
+		query: includeModulePaths ? '?includeModulePaths' : null
 	};
 	// Remove CRs to make test line ending invariant
 	var fixtureContent = fs.readFileSync(filename, "utf-8").replace(/\r/g, '');
@@ -179,5 +180,26 @@ describe("source-map-loader", function() {
 			deps.should.be.eql([]);
 			done();
 		});
+	});
+
+	it("should prepend the full path from the current working directory to the module", function(done) {
+		execLoader(path.join(__dirname, "fixtures", "external-source-map.js"), function(err, res, map, deps, warns) {
+			should.equal(err, null);
+			warns.should.be.eql([]);
+			map.sources.should.be.eql([
+				"test/fixtures/external-source-map.txt"
+			]);
+			done();
+		}, true);
+	});
+	it("should prepend the full path from the current working directory to the module (external sources)", function(done) {
+		execLoader(path.join(__dirname, "fixtures", "external-source-map2.js"), function(err, res, map, deps, warns) {
+			should.equal(err, null);
+			warns.should.be.eql([]);
+			map.sources.should.be.eql([
+				"test/fixtures/external-source-map2.txt"
+			]);
+			done();
+		}, true);
 	});
 });


### PR DESCRIPTION
This pull request is similar to #9. If the loader is configured with `includeModulePaths` set to `true`, the path of the source file will be computed relative to the current working directory if possible. This maintains the default behavior for most users but allows users to opt-into this behavior.