### PR TITLE
docs(readme): updates for JSF maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ This extracts all SourceMaps from all files. That's not so performance-wise so y
 </table>
 
 
-[npm]: https://img.shields.io/npm/v/sourcemap-loader.svg
-[npm-url]: https://npmjs.com/package/sourcemap-loader
+[npm]: https://img.shields.io/npm/v/source-map-loader.svg
+[npm-url]: https://npmjs.com/package/source-map-loader
 
-[deps]: https://david-dm.org/webpack-contrib/sourcemap-loader.svg
-[deps-url]: https://david-dm.org/webpack-contrib/sourcemap-loader
+[deps]: https://david-dm.org/webpack-contrib/source-map-loader.svg
+[deps-url]: https://david-dm.org/webpack-contrib/source-map-loader
 
 [chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
 [chat-url]: https://gitter.im/webpack/webpack

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
-# source map loader for webpack
+[![npm][npm]][npm-url]
+[![deps][deps]][deps-url]
+[![chat][chat]][chat-url]
 
-Extracts SourceMaps for source files that as added as `sourceMappingURL` comment.
+<div align="center">
+  <!-- replace with accurate logo e.g from https://worldvectorlogo.com/ -->
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" vspace="" hspace="25"
+      src="https://cdn.rawgit.com/webpack/media/e7485eb2/logo/icon.svg">
+  </a>
+  <h1>Sourcemap Loader</h1>
+  <p>Extracts SourceMaps for source files that as added as `sourceMappingURL` comment.<p>
+</div>
 
-## Usage
+<h2 align="center">Install</h2>
+
+```bash
+npm i -D sourcemap-loader
+```
+
+<h2 align="center">Usage</h2>
 
 [Documentation: Using loaders](https://webpack.js.org/concepts/#loaders)
 
@@ -25,6 +41,45 @@ module.exports = {
 
 This extracts all SourceMaps from all files. That's not so performance-wise so you may only want to apply the loader to relevant files.
 
-## License
+<h2 align="center">Maintainers</h2>
 
-MIT (http://www.opensource.org/licenses/mit-license.php)
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/166921?v=3&s=150">
+        </br>
+        <a href="https://github.com/bebraw">Juho Vepsäläinen</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars2.githubusercontent.com/u/8420490?v=3&s=150">
+        </br>
+        <a href="https://github.com/d3viant0ne">Joshua Wiens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/533616?v=3&s=150">
+        </br>
+        <a href="https://github.com/SpaceK33z">Kees Kluskens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/3408176?v=3&s=150">
+        </br>
+        <a href="https://github.com/TheLarkInn">Sean Larkin</a>
+      </td>
+    </tr>
+  <tbody>
+</table>
+
+
+[npm]: https://img.shields.io/npm/v/sourcemap-loader.svg
+[npm-url]: https://npmjs.com/package/sourcemap-loader
+
+[deps]: https://david-dm.org/webpack-contrib/sourcemap-loader.svg
+[deps-url]: https://david-dm.org/webpack-contrib/sourcemap-loader
+
+[chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
+[chat-url]: https://gitter.im/webpack/webpack


### PR DESCRIPTION
As part of the effort to reach compliance with JSF and get the CLA bot enabled, maintainers need to be clearly displayed.

While I was at it, I did the updates to the readme using the template chosen for the standards effort.