### PR TITLE
Fix module name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <h2 align="center">Install</h2>
 
 ```bash
-npm i -D sourcemap-loader
+npm i -D source-map-loader
 ```
 
 <h2 align="center">Usage</h2>


### PR DESCRIPTION
Most people will probably notice this and fix it, but here's a PR if you didn't realise this typo was on there.