### PR TITLE
Load source map only from last directive

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var path = require("path");
 var async = require("async");
 var loaderUtils = require("loader-utils");
 
-var baseRegex = "\\s*[@#]\\s*sourceMappingURL\\s*=\\s*([^\\s]*)",
+// Matches only the last occurrence of sourceMappingURL
+var baseRegex = "\\s*[@#]\\s*sourceMappingURL\\s*=\\s*([^\\s]*)(?![\S\s]*sourceMappingURL)",
 	// Matches /* ... */ comments
 	regex1 = new RegExp("/\\*"+baseRegex+"\\s*\\*/"),
 	// Matches // .... comments

--- a/test/fixtures/multi-source-map.js
+++ b/test/fixtures/multi-source-map.js
@@ -1,0 +1,4 @@
+with SourceMap
+anInvalidDirective = "\n/*# sourceMappingURL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
+//    @    sourceMappingURL    =    data:application/source-map;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5saW5lLXNvdXJjZS1tYXAuanMiLCJzb3VyY2VzIjpbImlubGluZS1zb3VyY2UtbWFwLnR4dCJdLCJzb3VyY2VzQ29udGVudCI6WyJ3aXRoIFNvdXJjZU1hcCJdLCJtYXBwaW5ncyI6IkFBQUEifQ==
+// comment

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,7 +33,9 @@ function execLoader(filename, callback) {
 			return this.callback;
 		}
 	};
-	var res = loader.call(context, fs.readFileSync(filename, "utf-8"));
+	// Remove CRs to make test line ending invariant
+	var fixtureContent = fs.readFileSync(filename, "utf-8").replace(/\r/g, '');
+	var res = loader.call(context, fixtureContent);
 	if(!async) return callback(null, res, null, deps, warns);
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -107,6 +107,24 @@ describe("source-map-loader", function() {
 			done();
 		});
 	});
+	it("should use last SourceMap directive", function (done) {
+		execLoader(path.join(__dirname, "fixtures", "multi-source-map.js"), function (err, res, map, deps, warns) {
+			should.equal(err, null);
+			warns.should.be.eql([]);
+			should.equal(res, "with SourceMap\nanInvalidDirective = \"\\n/*# sourceMappingURL=data:application/json;base64,\" + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + \" */\";\n// comment"),
+				map.should.be.eql({
+					"version": 3,
+					"file": "inline-source-map.js",
+					"sources": [
+						"inline-source-map.txt"
+					],
+					"sourcesContent": ["with SourceMap"],
+					"mappings": "AAAA"
+				});
+			deps.should.be.eql([]);
+			done();
+		});
+	});
 	it("should warn on missing SourceMap", function(done) {
 		execLoader(path.join(__dirname, "fixtures", "missing-source-map.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**
Yes.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
There is a library bundled by webpack with `style-loader`. A consumer tries to load it through webpack with `source-map-loader`, but it fails to build.



The root cause is `source-map-loader` incorrectly thinks the string literal `"\n/*# sourceMappingURL=data:application/json;base64,"` is a directive for source map, it tries to find the source map here(while the actual source map directive is in the end of file), and fails.

Per source map spec, the directive should appear at the last line of js file. Thus it makes sense to use last match as the one we read source map from.

**Does this PR introduce a breaking change?**
No.

**Other information**

Relates to: webpack-contrib/style-loader#181