### PR TITLE
Elaborate on plugin usage and benefits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ module.exports = {
 };
 ```
 
-This extracts SourceMaps from all js files (including node_modules). This is not very performant, so you may want to only apply the loader to relevant files.
+<p>`source-map-loader` extracts existing [sourcemaps](http://blog.teamtreehouse.com/introduction-source-maps) from all JavaScript entries.  This includes both inline sourcemaps as well as map data linked via URL. All map data is passed to WebPack for processing as per a chosen [source mapping style](https://webpack.js.org/configuration/devtool/) specified by the `devtool` option in [webpack.conf.js](https://webpack.js.org/configuration/).</p>
+
+<p>This loader is especially useful when including 3rd-party libraries having their own source maps. If not extracted and processed into the map of the WebPack bundle, browsers may misinterpret map data. `source-map-loader` allows Webpack to maintain map data continuity across libraries so ease of debugging is preserved.</p>
+
+<p>`source-map-loader` will extract from any JavaScript file, including those in the `node_modules` directory. Be mindful in setting [include](https://webpack.js.org/configuration/module/#rule-include) and [exclude](https://webpack.js.org/configuration/module/#rule-exclude) rule conditions to maximize bundling performance.</p>
 
 <h2 align="center">Maintainers</h2>
 


### PR DESCRIPTION
This expands on the `source-map-loader` purpose and usage on the main `README.md`.

This PR was previously https://github.com/webpack-contrib/source-map-loader/pull/35 but was remake due to user configuration error in `.git/config`.