### PR TITLE
fix: Regex does not work for minified artifact of style-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var async = require("async");
 var loaderUtils = require("loader-utils");
 
 // Matches only the last occurrence of sourceMappingURL
-var baseRegex = "\\s*[@#]\\s*sourceMappingURL\\s*=\\s*([^\\s]*)(?![\S\s]*sourceMappingURL)",
+var baseRegex = "\\s*[@#]\\s*sourceMappingURL\\s*=\\s*([^\\s]*)(?![\\S\\s]*sourceMappingURL)",
 	// Matches /* ... */ comments
 	regex1 = new RegExp("/\\*"+baseRegex+"\\s*\\*/"),
 	// Matches // .... comments

--- a/test/fixtures/multi-source-map.js
+++ b/test/fixtures/multi-source-map.js
@@ -1,4 +1,4 @@
 with SourceMap
-anInvalidDirective = "\n/*# sourceMappingURL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
+anInvalidDirective = "\n/*# sourceMappingURL=data:application/json;base64,"+btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap))))+" */";
 //    @    sourceMappingURL    =    data:application/source-map;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5saW5lLXNvdXJjZS1tYXAuanMiLCJzb3VyY2VzIjpbImlubGluZS1zb3VyY2UtbWFwLnR4dCJdLCJzb3VyY2VzQ29udGVudCI6WyJ3aXRoIFNvdXJjZU1hcCJdLCJtYXBwaW5ncyI6IkFBQUEifQ==
 // comment

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,7 +113,7 @@ describe("source-map-loader", function() {
 		execLoader(path.join(__dirname, "fixtures", "multi-source-map.js"), function (err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
-			should.equal(res, "with SourceMap\nanInvalidDirective = \"\\n/*# sourceMappingURL=data:application/json;base64,\" + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + \" */\";\n// comment"),
+			should.equal(res, "with SourceMap\nanInvalidDirective = \"\\n/*# sourceMappingURL=data:application/json;base64,\"+btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap))))+\" */\";\n// comment"),
 				map.should.be.eql({
 					"version": 3,
 					"file": "inline-source-map.js",


### PR DESCRIPTION
This PR is to fix some cases for PR #31 

In minified artifacts of `style-loader`, there is no space in js file, which couldn't be handled by the regex. It is fixed in this PR, and test cases updated accordingly.