### PR TITLE
fix: Handle exception on loading invalid source maps (#65)

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,9 +52,9 @@ module.exports = function(input, inputMap) {
 					}
 					var map;
 					try {
-						map = JSON.parse(content)
+						map = JSON.parse(content);
 					} catch (e) {
-						emitWarning("Cannot parse SourceMap '" + result + "': " + e);
+						emitWarning("Cannot parse SourceMap '" + url + "': " + e);
 						return untouched();				
 					}
 					processMap(map, path.dirname(result), callback);

--- a/index.js
+++ b/index.js
@@ -50,7 +50,14 @@ module.exports = function(input, inputMap) {
 						emitWarning("Cannot open SourceMap '" + result + "': " + err);
 						return untouched();
 					}
-					processMap(JSON.parse(content), path.dirname(result), callback);
+					var map;
+					try {
+						map = JSON.parse(content)
+					} catch (e) {
+						emitWarning("Cannot parse SourceMap '" + result + "': " + e);
+						return untouched();				
+					}
+					processMap(map, path.dirname(result), callback);
 				});
 			}.bind(this));
 			return;

--- a/test/fixtures/invalid-source-map.js
+++ b/test/fixtures/invalid-source-map.js
@@ -1,0 +1,3 @@
+with SourceMap
+//#sourceMappingURL=invalid-source-map.map
+// comment

--- a/test/fixtures/invalid-source-map.map
+++ b/test/fixtures/invalid-source-map.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"invalid-source-map.js","sources":["../invalid-source-map.txt"],"mappings":"AAAA"}"}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -149,6 +149,20 @@ describe("source-map-loader", function() {
 			done();
 		});
 	});
+	it("should warn on invalid SourceMap", function (done) {
+		execLoader(path.join(__dirname, "fixtures", "invalid-source-map.js"), function (err, res, map, deps, warns) {
+			should.equal(err, null);
+			warns.should.matchEach(
+				new RegExp("Cannot parse SourceMap 'invalid-source-map.map': SyntaxError: Unexpected string in JSON at position 102")
+			);
+			should.equal(res, "with SourceMap\n//#sourceMappingURL=invalid-source-map.map\n// comment");
+			should.equal(map, null);
+			deps.should.be.eql([
+				path.join(__dirname, "fixtures", "invalid-source-map.map")
+			]);
+			done();
+		});
+	});
 	it("should warn on missing SourceMap", function(done) {
 		execLoader(path.join(__dirname, "fixtures", "missing-source-map.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);


### PR DESCRIPTION
Added a try catch that's pretty much the same as the base64 fix.