### PR TITLE
map.sources converted to absolute paths + other changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.js]
+indent_style = tab

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(input, inputMap) {
 		callback = this.async();
 		if(dataUrlMatch) {
 			var mapBase64 = dataUrlMatch[1];
-			var mapStr = (new Buffer(mapBase64, "base64")).toString();
+			var mapStr = Buffer.from(mapBase64, "base64").toString();
 			var map;
 			try {
 				map = JSON.parse(mapStr)

--- a/index.js
+++ b/index.js
@@ -43,19 +43,20 @@ module.exports = function(input, inputMap) {
 			try {
 				map = JSON.parse(mapStr)
 			} catch (e) {
-				emitWarning("Cannot parse inline SourceMap '" + mapBase64.substr(0, 50) + "': " + e);
+				emitWarning(new Error("Cannot parse inline SourceMap '"
+					+ mapBase64.substr(0, 50) + "': " + e));
 				return untouched();
 			}
 			processMap(map, this.context, callback);
 		} else {
 			resolveAbsolutePath(this.context, url, function(err, absoluteFilepath) {
 				if(err) {
-					emitWarning("Cannot find SourceMap '" + url + "': " + err);
+					emitWarning(new Error("Cannot find SourceMap '" + url + "': " + err));
 					return untouched();
 				}
 				fs.readFile(absoluteFilepath, "utf-8", function(err, content) {
 					if(err) {
-						emitWarning("Cannot open SourceMap '" + absoluteFilepath + "': " + err);
+						emitWarning(new Error("Cannot open SourceMap '" + absoluteFilepath + "': " + err));
 						return untouched();
 					}
 					addDependency(absoluteFilepath);
@@ -63,7 +64,7 @@ module.exports = function(input, inputMap) {
 					try {
 						map = JSON.parse(content);
 					} catch (e) {
-						emitWarning("Cannot parse SourceMap '" + url + "': " + e);
+						emitWarning(new Error("Cannot parse SourceMap '" + url + "': " + e));
 						return untouched();
 					}
 					processMap(map, path.dirname(absoluteFilepath), callback);
@@ -101,7 +102,7 @@ module.exports = function(input, inputMap) {
 		const sourcesPromises = sources.map((source, sourceIndex) => new Promise((resolveSource) => {
 			resolveAbsolutePath(context, source, function(err, absoluteFilepath) {
 				if(err) {
-					emitWarning("Cannot find source file '" + source + "': " + err);
+					emitWarning(new Error("Cannot find source file '" + source + "': " + err));
 					return resolveSource({
 						source: source,
 						content: sourcesContent[sourceIndex] != null ? sourcesContent[sourceIndex] : null
@@ -115,7 +116,7 @@ module.exports = function(input, inputMap) {
 				}
 				fs.readFile(absoluteFilepath, "utf-8", function(err, content) {
 					if(err) {
-						emitWarning("Cannot open source file '" + absoluteFilepath + "': " + err);
+						emitWarning(new Error("Cannot open source file '" + absoluteFilepath + "': " + err));
 						return resolveSource({
 							source: absoluteFilepath,
 							content: null

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,19 +61,16 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "requires": {
-        "lodash": "^4.14.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -582,6 +579,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1018,6 +1020,11 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -1061,6 +1068,16 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "requires": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -1074,7 +1091,8 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,11 +75,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -587,11 +582,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1028,11 +1018,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -1074,16 +1059,6 @@
         "parse-json": "^4.0.0",
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "loader-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
       }
     },
     "locate-path": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "async": "^2.5.0"
+    "loader-utils": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "async": "^2.5.0",
-    "loader-utils": "^1.1.0"
+    "async": "^2.5.0"
   },
   "devDependencies": {
     "mocha": "^5.0.5",

--- a/test/fixtures/null-sourcesContent-source-map.js
+++ b/test/fixtures/null-sourcesContent-source-map.js
@@ -1,0 +1,2 @@
+with SourceMap
+//#sourceMappingURL=null-sourcesContent-source-map.map

--- a/test/fixtures/null-sourcesContent-source-map.map
+++ b/test/fixtures/null-sourcesContent-source-map.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"null-sourcesContent-source-map.js","sources":["null-sourcesContent-source-map.txt"],"sourcesContent":[null],"mappings":"AAAA"}

--- a/test/fixtures/null-sourcesContent-source-map.txt
+++ b/test/fixtures/null-sourcesContent-source-map.txt
@@ -1,0 +1,1 @@
+with SourceMap

--- a/test/fixtures/relative-sourceRoot-sourcesContent-source-map.js
+++ b/test/fixtures/relative-sourceRoot-sourcesContent-source-map.js
@@ -1,0 +1,2 @@
+with SourceMap
+//#sourceMappingURL=relative-sourceRoot-sourcesContent-source-map.map

--- a/test/fixtures/relative-sourceRoot-sourcesContent-source-map.map
+++ b/test/fixtures/relative-sourceRoot-sourcesContent-source-map.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"relative-sourceRoot-sourcesContent-source-map.js","sourceRoot":"../fixtures/data/","sources":["relative-sourceRoot-sourcesContent-source-map.txt"],"sourcesContent":["with SourceMap"],"mappings":"AAAA"}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -176,10 +176,10 @@ describe("source-map-loader", function() {
 	it("should warn on missing SourceMap", function(done) {
 		execLoader(path.join(fixturesPath, "missing-source-map.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
-			warns.should.be.eql([
-				"Cannot find SourceMap 'missing-source-map.map': Error: File not found"
-			]);
-			should.equal(res, "with SourceMap\n//#sourceMappingURL=missing-source-map.map\n// comment"),
+			warns.should.matchEach(
+				new RegExp(`Cannot open SourceMap '${path.join(fixturesPath, 'missing-source-map.map')}':`)
+			);
+			should.equal(res, "with SourceMap\n//#sourceMappingURL=missing-source-map.map\n// comment");
 			should.equal(map, null);
 			deps.should.be.eql([]);
 			done();
@@ -189,10 +189,10 @@ describe("source-map-loader", function() {
 	it("should warn on missing source file", function(done) {
 		execLoader(path.join(fixturesPath, "missing-source-map2.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
-			warns.should.be.eql([
-				"Cannot find source file 'missing-source-map2.txt': Error: File not found"
-			]);
-			should.equal(res, "with SourceMap\n// comment"),
+			warns.should.matchEach(
+				new RegExp(`Cannot open source file '${path.join(fixturesPath, 'missing-source-map2.txt')}':`)
+			);
+			should.equal(res, "with SourceMap\n// comment");
 			map.should.be.eql({
 				"version":3,
 				"file":"missing-source-map2.js",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -336,4 +336,36 @@ describe("source-map-loader", function() {
 			}
 		);
 	});
+
+	it("should resolve relative sources path even with sourcesContent", (done) => {
+		const javaScriptFilename = "relative-sourceRoot-sourcesContent-source-map.js";
+		const sourceFilename = "relative-sourceRoot-sourcesContent-source-map.txt";
+		const rootRelativeSourcePath = path.join(dataPath, sourceFilename);
+		const sourceMapPath = path.join(fixturesPath, "relative-sourceRoot-sourcesContent-source-map");
+
+		execLoader(
+			path.join(fixturesPath, javaScriptFilename),
+			(err, res, map, deps, warns) => {
+				should.equal(err, null);
+				warns.should.be.eql([]);
+				should.equal(res, "with SourceMap\n");
+				map.should.be.eql({
+					"version": 3,
+					"file": javaScriptFilename,
+					"sources": [
+						rootRelativeSourcePath
+					],
+					"sourcesContent": [
+						"with SourceMap"
+					],
+					"mappings": "AAAA"
+				});
+				deps.should.be.eql([
+					sourceMapPath,
+					rootRelativeSourcePath
+				]);
+				done();
+			}
+		);
+	});
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -304,4 +304,36 @@ describe("source-map-loader", function() {
 			}
 		);
 	});
+
+	it("should support null value in sourcesContent", (done) => {
+		const javaScriptFilename = "null-sourcesContent-source-map.js";
+		const sourceFilename = "null-sourcesContent-source-map.txt";
+		const rootRelativeSourcePath = path.join(fixturesPath, sourceFilename);
+		const sourceMapPath = path.join(fixturesPath, "null-sourcesContent-source-map.map");
+
+		execLoader(
+			path.join(fixturesPath, javaScriptFilename),
+			(err, res, map, deps, warns) => {
+				should.equal(err, null);
+				warns.should.be.eql([]);
+				should.equal(res, "with SourceMap\n");
+				map.should.be.eql({
+					"version": 3,
+					"file": javaScriptFilename,
+					"sources": [
+						rootRelativeSourcePath
+					],
+					"sourcesContent": [
+						"with SourceMap"
+					],
+					"mappings": "AAAA"
+				});
+				deps.should.be.eql([
+					sourceMapPath,
+					rootRelativeSourcePath
+				]);
+				done();
+			}
+		);
+	});
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,7 +47,7 @@ describe("source-map-loader", function() {
 		execLoader(path.join(fixturesPath, "normal-file.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
-			should.equal(res, "without SourceMap"),
+			should.equal(res, "without SourceMap");
 			should.equal(map, null);
 			deps.should.be.eql([]);
 			done();
@@ -58,12 +58,12 @@ describe("source-map-loader", function() {
 		execLoader(path.join(fixturesPath, "inline-source-map.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
-			should.equal(res, "with SourceMap\n// comment"),
+			should.equal(res, "with SourceMap\n// comment");
 			map.should.be.eql({
 				"version":3,
 				"file":"inline-source-map.js",
 				"sources":[
-					"inline-source-map.txt"
+					path.join(fixturesPath,"inline-source-map.txt")
 				],
 				"sourcesContent":["with SourceMap"],
 				"mappings":"AAAA"
@@ -77,12 +77,12 @@ describe("source-map-loader", function() {
 		execLoader(path.join(fixturesPath, "external-source-map.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
-			should.equal(res, "with SourceMap\n// comment"),
+			should.equal(res, "with SourceMap\n// comment");
 			map.should.be.eql({
 				"version":3,
 				"file":"external-source-map.js",
 				"sources":[
-					"external-source-map.txt"
+					path.join(fixturesPath,"external-source-map.txt")
 				],
 				"sourcesContent":["with SourceMap"],
 				"mappings":"AAAA"
@@ -98,7 +98,7 @@ describe("source-map-loader", function() {
 		execLoader(path.join(fixturesPath, "external-source-map2.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
-			should.equal(res, "with SourceMap\n// comment"),
+			should.equal(res, "with SourceMap\n// comment");
 			map.should.be.eql({
 				"version":3,
 				"file":"external-source-map2.js",
@@ -120,12 +120,12 @@ describe("source-map-loader", function() {
 		execLoader(path.join(fixturesPath, "multi-source-map.js"), function (err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
-			should.equal(res, "with SourceMap\nanInvalidDirective = \"\\n/*# sourceMappingURL=data:application/json;base64,\"+btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap))))+\" */\";\n// comment"),
+			should.equal(res, "with SourceMap\nanInvalidDirective = \"\\n/*# sourceMappingURL=data:application/json;base64,\"+btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap))))+\" */\";\n// comment");
 				map.should.be.eql({
 					"version": 3,
 					"file": "inline-source-map.js",
 					"sources": [
-						"inline-source-map.txt"
+						path.join(fixturesPath,"inline-source-map.txt")
 					],
 					"sourcesContent": ["with SourceMap"],
 					"mappings": "AAAA"
@@ -197,7 +197,7 @@ describe("source-map-loader", function() {
 				"version":3,
 				"file":"missing-source-map2.js",
 				"sources":[
-					"missing-source-map2.txt"
+					path.join(fixturesPath,"missing-source-map2.txt")
 				],
 				"sourcesContent":[null],
 				"mappings":"AAAA"
@@ -213,12 +213,12 @@ describe("source-map-loader", function() {
 		execLoader(path.join(fixturesPath, "charset-inline-source-map.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);
 			warns.should.be.eql([]);
-			should.equal(res, "with SourceMap\n// comment"),
+			should.equal(res, "with SourceMap\n// comment");
 			map.should.be.eql({
 				"version":3,
 				"file":"charset-inline-source-map.js",
 				"sources":[
-					"charset-inline-source-map.txt"
+					path.join(fixturesPath,"charset-inline-source-map.txt")
 				],
 				"sourcesContent":["with SourceMap"],
 				"mappings":"AAAA"
@@ -252,7 +252,7 @@ describe("source-map-loader", function() {
 			(err, res, map, deps, warns) => {
 				should.equal(err, null);
 				warns.should.be.eql([]);
-				should.equal(res, "with SourceMap\n// comment"),
+				should.equal(res, "with SourceMap\n// comment");
 				map.should.be.eql({
 					"version": 3,
 					"file": javaScriptFilename,
@@ -284,7 +284,7 @@ describe("source-map-loader", function() {
 			(err, res, map, deps, warns) => {
 				should.equal(err, null);
 				warns.should.be.eql([]);
-				should.equal(res, "with SourceMap\n// comment"),
+				should.equal(res, "with SourceMap\n// comment");
 				map.should.be.eql({
 					"version": 3,
 					"file": javaScriptFilename,
@@ -341,7 +341,7 @@ describe("source-map-loader", function() {
 		const javaScriptFilename = "relative-sourceRoot-sourcesContent-source-map.js";
 		const sourceFilename = "relative-sourceRoot-sourcesContent-source-map.txt";
 		const rootRelativeSourcePath = path.join(dataPath, sourceFilename);
-		const sourceMapPath = path.join(fixturesPath, "relative-sourceRoot-sourcesContent-source-map");
+		const sourceMapPath = path.join(fixturesPath, "relative-sourceRoot-sourcesContent-source-map.map");
 
 		execLoader(
 			path.join(fixturesPath, javaScriptFilename),
@@ -361,8 +361,7 @@ describe("source-map-loader", function() {
 					"mappings": "AAAA"
 				});
 				deps.should.be.eql([
-					sourceMapPath,
-					rootRelativeSourcePath
+					sourceMapPath
 				]);
 				done();
 			}


### PR DESCRIPTION
**Motivation:**
Webpack generates useless paths in sourcemaps when the original sourcemap contains relative paths. For example `{"sources":["../../src/MyComponent.js"]}` will generate `webpack://../../src/MyComponent.js`

**This PR contains the following changes:**

- The `sources` in the returned map are now converted to absolute paths. I added an option `keepRelativeSources` to prevent this behavior. The behavior is enabled by default because it improves the source map generation by webpack.
- The loader doesn't use webpack's `this.resolve` to resolve the sources path. The reason is that sources are URIs (or paths) not meant to be resolved by webpack. (The first reason was `resolve` fails if the file doesn't actually exist)
- The loader will try to load sources from disk when the `sourcesContent` value is `null`
- Some code "cleaning"/"refactoring": use of Promises internally, remove deprecated `new Buffer`, add .editorconfig for tabs

----

By the way, I've got these suggestions while working on this PR:
- Prevent reading SourceMap/Sources from files not in the same npm package as the resource, by default. (prevent things like `//#sourceMappingURL=/etc/passwd`)
- Add an option to force URLs in the map's `sources` list, for webpack/webpack#8226
