### PR TITLE
add test for not loading SourceMaps in strings

### DIFF
--- a/test/fixtures/normal-file2.js
+++ b/test/fixtures/normal-file2.js
@@ -1,0 +1,3 @@
+without SourceMap
+anInvalidDirective = "\n/*# sourceMappingURL=data:application/json;base64,"+btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap))))+" */";
+// comment

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,6 +54,17 @@ describe("source-map-loader", function() {
 		});
 	});
 
+	it("should not process source maps in strings", function(done) {
+		execLoader(path.join(fixturesPath, "normal-file2.js"), function(err, res, map, deps, warns) {
+			should.equal(err, null);
+			warns.should.be.eql([]);
+			should.equal(res, "without SourceMap\nanInvalidDirective = \"\\n/*# sourceMappingURL=data:application/json;base64,\"+btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap))))+\" */\";\n// comment"),
+			should.equal(map, null);
+			deps.should.be.eql([]);
+			done();
+		});
+	});
+
 	it("should process inlined SourceMaps", function(done) {
 		execLoader(path.join(fixturesPath, "inline-source-map.js"), function(err, res, map, deps, warns) {
 			should.equal(err, null);


### PR DESCRIPTION
This PR adds a test for #55, which is an issue I encountered while trying to load a file that didn't have a source map, but looked like it did (e.g. [VideoPlayer.js](https://unpkg.com/@bbc/react-transcript-editor@1.0.2/VideoPlayer.js)).

This issue was almost fixed by PR #31, but that PR assumed that every file with a "fake" source map also had a real source map at the end.

I'm not sure of the best way to fix this, so I'm just adding a failing test for now. I'd be happy to implement a fix once I know of a good approach.