### PR TITLE
fix(index): fix crash with indexed source maps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 /node_modules
 /test/fixtures
 CHANGELOG.md
+.history

--- a/package-lock.json
+++ b/package-lock.json
@@ -3460,6 +3460,11 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -4371,7 +4376,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -4707,7 +4712,7 @@
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
@@ -4785,7 +4790,7 @@
     },
     "conventional-changelog-angular": {
       "version": "1.6.6",
-      "resolved": "http://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
@@ -6964,6 +6969,24 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "flatten-source-map": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/flatten-source-map/-/flatten-source-map-0.0.2.tgz",
+      "integrity": "sha1-yNWvAxTrZHbc2HyPHsj+sqZ+8D0=",
+      "requires": {
+        "source-map": "^0.1.43"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -8261,7 +8284,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -8380,7 +8403,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -11873,7 +11896,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -12597,7 +12620,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -13006,7 +13029,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -14292,7 +14315,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -14318,7 +14341,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -14333,7 +14356,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -14582,7 +14605,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "data-urls": "^2.0.0",
+    "flatten-source-map": "0.0.2",
     "loader-utils": "^2.0.0",
     "neo-async": "^2.6.1",
     "schema-utils": "^2.6.6",

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,12 @@
 import fs from 'fs';
 import path from 'path';
 
-import validateOptions from 'schema-utils';
-import async from 'neo-async';
-import parseDataURL from 'data-urls';
-import { labelToName, decode } from 'whatwg-encoding';
 import { getOptions, urlToRequest } from 'loader-utils';
+import { labelToName, decode } from 'whatwg-encoding';
+import async from 'neo-async';
+import flattenSourceMap from 'flatten-source-map';
+import parseDataURL from 'data-urls';
+import validateOptions from 'schema-utils';
 
 import schema from './options.json';
 
@@ -113,8 +114,12 @@ export default function loader(input, inputMap) {
   });
 
   // eslint-disable-next-line no-shadow
-  function processMap(map, context, callback) {
-    if (!map.sourcesContent || map.sourcesContent.length < map.sources.length) {
+  function processMap(inputMap, context, callback) {
+    if (
+      !inputMap.sourcesContent ||
+      inputMap.sourcesContent.length < inputMap.sources.length
+    ) {
+      const map = inputMap.sections ? flattenSourceMap(inputMap) : inputMap;
       const sourcePrefix = map.sourceRoot ? `${map.sourceRoot}/` : '';
 
       // eslint-disable-next-line no-param-reassign
@@ -184,6 +189,6 @@ export default function loader(input, inputMap) {
       return;
     }
 
-    callback(null, input.replace(match[0], ''), map);
+    callback(null, input.replace(match[0], ''), inputMap);
   }
 }

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -52,6 +52,56 @@ Object {
 
 exports[`source-map-loader should process external SourceMaps: warnings 1`] = `Array []`;
 
+exports[`source-map-loader should process indexed source maps (sections): css 1`] = `
+"with SourceMap
+// From https://github.com/DavidSouther/flatten-source-map/blob/master/lib/test.js
+// comment"
+`;
+
+exports[`source-map-loader should process indexed source maps (sections): errors 1`] = `Array []`;
+
+exports[`source-map-loader should process indexed source maps (sections): map 1`] = `
+Object {
+  "file": "app.js",
+  "mappings": "AAAA;AAAA,EAAA,OAAO,CAAC,MAAR,CAAe,eAAf,EAAgC,CAC5B,0BAD4B,EAE5B,eAF4B,CAAhC,CAAA,CAAA;AAAA;;;;;ACAA,OAAO,CAAC,MAAM,CAAC,2BAA2B,EAAE;AAC5C,CAAC,CAAC,CAAC,OAAO,CAAC,QAAQ,EAAE,SAAS,MAAM,CAAC,CAAC;IAClC,IAAI,CAAC,QAAQ,EAAE,IAAI,IAAI,CAAC,CAAC;AAC7B,CAAC,CAAC;;;;ACHF;AAAA,MAAA,QAAA;;AAAA,EAAM;AACW,IAAA,kBAAA,GAAA,CAAb;;oBAAA;;MADJ,CAAA;;AAAA,EAGA,OAAO,CAAC,MAAR,CAAe,0BAAf,EAA2C,EAA3C,CACA,CAAC,UADD,CACY,UADZ,EACwB,QADxB,CAHA,CAAA;AAAA;;;ACAA;AAAA,EAAA,OAAO,CAAC,MAAR,CAAe,6BAAf,EAA8C,CAC1C,mBAD0C,EAE1C,kBAF0C,CAA9C,CAGE,CAAC,SAHH,CAGa,YAHb,EAG2B,SAAA,GAAA;WACvB;AAAA,MAAA,QAAA,EAAU,IAAV;AAAA,MACA,WAAA,EAAa,UADb;MADuB;EAAA,CAH3B,CAAA,CAAA;AAAA",
+  "names": Array [],
+  "sources": Array [
+    "main.coffee",
+    "service.js",
+    "controller.coffee",
+    "directive.coffee",
+  ],
+  "sourcesContent": Array [
+    "angular.module('stassets.main', [
+    'stassets.main.controller'
+    'main.template'
+])
+",
+    "angular.module('stassets.main.nav.service', [
+]).service('NavSvc', function NavSvc(){
+    this.started = new Date();
+});
+",
+    "class MainCtrl
+    constructor: ->
+
+angular.module('stassets.main.controller', [])
+.controller 'MainCtrl', MainCtrl
+",
+    "angular.module('stassets.main.nav.directive', [
+    'main.nav.template'
+    'main.nav.service'
+]).directive 'stassetNav', ->
+    restrict: 'AE'
+    templateUrl: 'main/nav'
+",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`source-map-loader should process indexed source maps (sections): warnings 1`] = `Array []`;
+
 exports[`source-map-loader should process inlined SourceMaps with charset: css 1`] = `
 "with SourceMap
 // comment"

--- a/test/fixtures/indexed-source-map.js
+++ b/test/fixtures/indexed-source-map.js
@@ -1,0 +1,4 @@
+with SourceMap
+// From https://github.com/DavidSouther/flatten-source-map/blob/master/lib/test.js
+//#sourceMappingURL=indexed-source-map.js.map
+// comment

--- a/test/fixtures/indexed-source-map.js.map
+++ b/test/fixtures/indexed-source-map.js.map
@@ -1,0 +1,51 @@
+{
+    "version":3,
+    "file":"app.js",
+    "sections":[
+      {
+        "map": {
+          "version":3,
+          "file":"",
+          "sourceRoot":"",
+          "sources":["main.coffee"],
+          "names":[],
+          "mappings":"AAAA;AAAA,EAAA,OAAO,CAAC,MAAR,CAAe,eAAf,EAAgC,CAC5B,0BAD4B,EAE5B,eAF4B,CAAhC,CAAA,CAAA;AAAA",
+          "sourcesContent":["angular.module('stassets.main', [\n    'stassets.main.controller'\n    'main.template'\n])\n"]
+        },
+        "offset":{"line":0,"column":0}
+      },
+      {
+        "map": {
+          "version":3,
+          "sources": ["service.js"],
+          "names": ["angular","module","service","NavSvc","started","Date"],
+          "mappings":";AAAAA,OAAO,CAACC,MAAM,CAAC,2BAA2B,EAAE;AAC5C,CAAC,CAAC,CAACC,OAAO,CAAC,QAAQ,EAAE,SAASC,MAAM,CAAC,CAAC;IAClC,IAAI,CAACC,QAAQ,EAAE,IAAIC,IAAI,CAAC,CAAC;AAC7B,CAAC,CAAC",
+          "file":"service.js",
+          "sourcesContent": ["angular.module('stassets.main.nav.service', [\n]).service('NavSvc', function NavSvc(){\n    this.started = new Date();\n});\n"]
+        },
+        "offset":{"line":6,"column":0}
+      },
+      {
+        "map":{
+          "version":3,
+          "file":"",
+          "sourceRoot":"",
+          "sources":["controller.coffee"],
+          "names":[],
+          "mappings":"AAAA;AAAA,MAAA,QAAA;;AAAA,EAAM;AACW,IAAA,kBAAA,GAAA,CAAb;;oBAAA;;MADJ,CAAA;;AAAA,EAGA,OAAO,CAAC,MAAR,CAAe,0BAAf,EAA2C,EAA3C,CACA,CAAC,UADD,CACY,UADZ,EACwB,QADxB,CAHA,CAAA;AAAA",
+          "sourcesContent":["class MainCtrl\n    constructor: ->\n\nangular.module('stassets.main.controller', [])\n.controller 'MainCtrl', MainCtrl\n"]
+        },"offset":{"line":14,"column":0}
+      },
+      {
+        "map":{
+          "version":3,
+          "file":"",
+          "sourceRoot":"",
+          "sources":["directive.coffee"],
+          "names":[],
+          "mappings":"AAAA;AAAA,EAAA,OAAO,CAAC,MAAR,CAAe,6BAAf,EAA8C,CAC1C,mBAD0C,EAE1C,kBAF0C,CAA9C,CAGE,CAAC,SAHH,CAGa,YAHb,EAG2B,SAAA,GAAA;WACvB;AAAA,MAAA,QAAA,EAAU,IAAV;AAAA,MACA,WAAA,EAAa,UADb;MADuB;EAAA,CAH3B,CAAA,CAAA;AAAA",
+          "sourcesContent":["angular.module('stassets.main.nav.directive', [\n    'main.nav.template'\n    'main.nav.service'\n]).directive 'stassetNav', ->\n    restrict: 'AE'\n    templateUrl: 'main/nav'\n"]
+        },"offset":{"line":28,"column":0}
+      }
+    ]
+  }

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -250,4 +250,17 @@ describe('source-map-loader', () => {
     expect(getWarnings(stats)).toMatchSnapshot('warnings');
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
+
+  it('should process indexed source maps (sections)', async () => {
+    const testId = 'indexed-source-map.js';
+    const compiler = getCompiler(testId);
+    const stats = await compile(compiler);
+    const codeFromBundle = getCodeFromBundle(stats, compiler);
+
+    expect(codeFromBundle.map).toBeDefined();
+    expect(normalizeMap(codeFromBundle.map)).toMatchSnapshot('map');
+    expect(codeFromBundle.css).toMatchSnapshot('css');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
 });


### PR DESCRIPTION
Indexed source maps are an alernate style in the Source Map Revision 3
spec that are not very well supported. This change uses an external tool
to flatten the source map into the standard form which webpack can then
parse

See also: https://sourcemaps.info/spec.html#h.535es3xeprgt

Fixes #89