### PR TITLE
feat: added option to skip resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,38 @@ module.exports = {
 
 More information about the `warningsFilters` option you can find [here](https://webpack.js.org/configuration/stats/#statswarningsfilter);
 
+### Skipping files
+
+You can provide custom callback function `skipResource` in order to instruct `source-map-loader` to skip processing of any source map it will find.
+To do that, pass the function as the loader option. Function receives two arguments: loader context object (as defined in (webpack reference)[https://webpack.js.org/api/loaders/#the-loader-context]) and the source map url found in file.
+Function should return a truthful value if processing source map for the file should be skipped.
+Source map url is the string which may be an absolute file path, relative file path, file url, http url or data url.
+
+Example configuration:
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        enforce: 'pre',
+        use: [
+          {
+            skipResource: (loaderContext, url) => {
+              // Load source map only for files in package "my-package"
+              return loaderContext.context.match(/node_modules[\\/]my-package/);
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
 ## Contributing
 
 Please take a moment to read our contributing guidelines if you haven't yet done so.

--- a/src/index.js
+++ b/src/index.js
@@ -18,10 +18,15 @@ export default async function loader(input, inputMap) {
     baseDataPath: 'options',
   });
 
+  const { skipResource } = options;
+
   const { sourceMappingURL, replacementString } = getSourceMappingURL(input);
   const callback = this.async();
 
-  if (!sourceMappingURL) {
+  const shouldSuppress =
+    sourceMappingURL && skipResource && skipResource(this, sourceMappingURL);
+
+  if (!sourceMappingURL || shouldSuppress) {
     callback(null, input, inputMap);
 
     return;

--- a/src/options.json
+++ b/src/options.json
@@ -1,4 +1,9 @@
 {
   "type": "object",
+  "properties": {
+    "skipResource": {
+      "instanceof": "Function"
+    }
+  },
   "additionalProperties": false
 }

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -423,7 +423,7 @@ Object {
 exports[`source-map-loader should skip webpack protocol path if sourcesContent is set: warnings 1`] = `Array []`;
 
 exports[`source-map-loader should support absolute paths to sourcemaps: css 1`] = `
-"// Some content
+"// Some content 
  "
 `;
 
@@ -474,7 +474,7 @@ Object {
 exports[`source-map-loader should support absolute sourceRoot paths in sourcemaps: warnings 1`] = `Array []`;
 
 exports[`source-map-loader should support file protocol path: css 1`] = `
-"// Some content
+"// Some content 
  "
 `;
 
@@ -562,7 +562,7 @@ Object {
 exports[`source-map-loader should support indexed sourcemaps: warnings 1`] = `Array []`;
 
 exports[`source-map-loader should support mixed paths in sources with sourceRoot: css 1`] = `
-"// Some content
+"// Some content 
  "
 `;
 
@@ -600,7 +600,7 @@ Failed to parse source map: \\"http://path-to-map.com\\" URL is not supported",
 `;
 
 exports[`source-map-loader should support mixed paths in sources without sourceRoot: css 1`] = `
-"// Some content
+"// Some content 
  "
 `;
 

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -347,6 +347,16 @@ Failed to parse source map: \\"ftp://exampleurl.com\\" URL is not supported",
 ]
 `;
 
+exports[`source-map-loader should skip SourceMaps for suppressed resources: css 1`] = `
+"with SourceMap
+//#sourceMappingURL=external-source-map.map
+// comment"
+`;
+
+exports[`source-map-loader should skip SourceMaps for suppressed resources: errors 1`] = `Array []`;
+
+exports[`source-map-loader should skip SourceMaps for suppressed resources: warnings 1`] = `Array []`;
+
 exports[`source-map-loader should skip file protocol path if sourcesContent is set: css 1`] = `
 "// Some content
  "
@@ -413,7 +423,7 @@ Object {
 exports[`source-map-loader should skip webpack protocol path if sourcesContent is set: warnings 1`] = `Array []`;
 
 exports[`source-map-loader should support absolute paths to sourcemaps: css 1`] = `
-"// Some content 
+"// Some content
  "
 `;
 
@@ -464,7 +474,7 @@ Object {
 exports[`source-map-loader should support absolute sourceRoot paths in sourcemaps: warnings 1`] = `Array []`;
 
 exports[`source-map-loader should support file protocol path: css 1`] = `
-"// Some content 
+"// Some content
  "
 `;
 
@@ -552,7 +562,7 @@ Object {
 exports[`source-map-loader should support indexed sourcemaps: warnings 1`] = `Array []`;
 
 exports[`source-map-loader should support mixed paths in sources with sourceRoot: css 1`] = `
-"// Some content 
+"// Some content
  "
 `;
 
@@ -590,7 +600,7 @@ Failed to parse source map: \\"http://path-to-map.com\\" URL is not supported",
 `;
 
 exports[`source-map-loader should support mixed paths in sources without sourceRoot: css 1`] = `
-"// Some content 
+"// Some content
  "
 `;
 

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -3,47 +3,47 @@
 exports[`validate options should throw an error on the "unknown" option with "/test/" value 1`] = `
 "Invalid options object. Source Map Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object {}"
+   object { skipResource? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "[]" value 1`] = `
 "Invalid options object. Source Map Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object {}"
+   object { skipResource? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. Source Map Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object {}"
+   object { skipResource? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "{}" value 1`] = `
 "Invalid options object. Source Map Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object {}"
+   object { skipResource? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "1" value 1`] = `
 "Invalid options object. Source Map Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object {}"
+   object { skipResource? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "false" value 1`] = `
 "Invalid options object. Source Map Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object {}"
+   object { skipResource? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "test" value 1`] = `
 "Invalid options object. Source Map Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object {}"
+   object { skipResource? }"
 `;
 
 exports[`validate options should throw an error on the "unknown" option with "true" value 1`] = `
 "Invalid options object. Source Map Loader has been initialized using an options object that does not match the API schema.
  - options has an unknown property 'unknown'. These properties are valid:
-   object {}"
+   object { skipResource? }"
 `;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -658,4 +658,28 @@ describe('source-map-loader', () => {
     expect(getWarnings(stats, true)).toMatchSnapshot('warnings');
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
+
+  it('should skip SourceMaps for suppressed resources', async () => {
+    const testId = 'external-source-map.js';
+    const compiler = getCompiler(testId, {
+      skipResource: (loaderContext, url) => {
+        return url === 'external-source-map.map';
+      },
+    });
+    const stats = await compile(compiler);
+    const codeFromBundle = getCodeFromBundle(stats, compiler);
+    const deps = stats.compilation.fileDependencies;
+
+    const dependencies = [
+      path.resolve(__dirname, 'fixtures', 'external-source-map.map'),
+    ];
+
+    dependencies.forEach((fixture) => {
+      expect(deps.has(fixture)).toBe(false);
+    });
+    expect(codeFromBundle.map).toBeUndefined();
+    expect(codeFromBundle.css).toMatchSnapshot('css');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
 });


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

While using this package to help debug my own dependencies, I have encountered quite a lot of packages which have broken sourcemaps. For example, a package may contain a sourcemap file, but won't contain the sources. Or it may have sourcemapping in the compiled files, but won't have the sourcemap file.

Currently for each missing sourcemap or source file this package emits a warning. These warnings can be disabled using `warningsFilter`, but I have failed to so in the context of `create-react-app`+`react-app-rewired`. That's because CRA uses `stats.toJson()` without providing a `warningsFilter` option to it (https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/WebpackDevServerUtils.js#L177, https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/scripts/build.js#L179). In the CI context each warning is treated as an error, so CI fails because of that. (btw, CRA has the PR to add `source-map-loader` into it: https://github.com/facebook/create-react-app/pull/8227)

I originally wanted to monkey-patch that by adding an option to disable all the warnings entirely in previous PR (https://github.com/webpack-contrib/source-map-loader/pull/122).
But @evilebottnawi suggested to provide a function to suppress loading of the sourcemaps on the individual basis.

There are two kind of requests which `source-map-loader` does. First is load the sourcemap file, and the second is to load the source file. Both may be broken, so I've added an option `skipResource` which accepts a function. If that function returns truthful value, the entire resource is skipped even before sourcemap file is read. Since I couldn't figure out, which properties may be useful to the user to decide whether to skip the resource or not, I've just supplied the entire `loaderContext` and `sourceMappingURL` to that function. 

Example webpack loader configuration:

```js
module.exports = {
  module: {
    rules: [
      {
        test: /\.js$/,
        enforce: 'pre',
        use: [
          {
            skipResource: (loaderContext, url) => {
              // Load source map only for files in package "my-package"
              return loaderContext.context.match(/node_modules[\\/]my-package/);
            },
          },
        ],
      },
    ],
  },
};
```

Maybe it will also be useful to add another function to skip source files themselves. Would like to hear some opinions about that.

### Breaking Changes

No breaking changes introduced. If `skipResource` is not provided, loader behaves the same as before.
