### PR TITLE
docs: fix ci for webpack.js.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ module.exports = {
 };
 ```
 
-More information about the `ignoreWarnings` option you can find [here](https://webpack.js.org/configuration/#options:~:text=ignoreWarnings);
-
 ## Contributing
 
 Please take a moment to read our contributing guidelines if you haven't yet done so.


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [  ] **bugfix**
- [  ] new **feature**
- [  ] **code refactor**
- [  ] **test update** <!-- if bug or feature is checked, this should be too -->
- [  ] **typo fix**
- [ x] **metadata update**

### Motivation / Use-Case

The link `https://webpack.js.org/configuration/#options:~:text=ignoreWarnings` was added in https://github.com/webpack-contrib/source-map-loader/pull/129, I think the author used it as a workaround because the URL should be used here is currently blocked by this pull request https://github.com/webpack/webpack.js.org/pull/4076.

Now `options:~:text=ignoreWarnings` was recognized as ID (which I believe is a bug as `:~:text=ignoreWarnings` is a [text fragment](https://wicg.github.io/scroll-to-text-fragment/#syntax), but I'm not sure if it'll be a bug in [hyperlink](https://github.com/Munter/hyperlink) or somewhere else) and webpack.js.org doesn't have it in the page which caused the [failure of CI](https://travis-ci.org/github/webpack/webpack.js.org/jobs/736620634#L777).

This pull request removes the paragraph temporarily to fix CI for webpack.js.org. We can add it back later when https://github.com/webpack/webpack.js.org/pull/4076 get merged.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
